### PR TITLE
chore: bump version to v0.4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tppt"
-version = "0.3.0"
+version = "0.4.0"
 description = "Typed Python PowerPoint Tool"
 readme = "README.md"
 requires-python = ">=3.11.0"

--- a/uv.lock
+++ b/uv.lock
@@ -1074,7 +1074,7 @@ wheels = [
 
 [[package]]
 name = "tppt"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "pillow" },


### PR DESCRIPTION
## Summary
- bump the package version from 0.3.0 to 0.4.0 in pyproject.toml
- keep uv.lock in sync with the new package version

## Testing
- not run (version metadata change only)